### PR TITLE
fixed the crash on destroy issue.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,9 +115,10 @@ class Ship extends Phaser.Physics.Arcade.Sprite {
         scene.physics.add.existing(scene.add.existing(this));
         this.setSize(12, 12);
         this.setDepth(1);
-        scene.events.on('update', (time, delta) => {
-            this.update(time, delta)
-        });
+    }
+    
+    preUpdate(time, delta) {
+        this.update(time, delta)
     }
 
     remove() {


### PR DESCRIPTION
I don't know why this fixes it exactly but I assume it causes some things to try and run as they're being destroyed so the references are removed while it's running the update